### PR TITLE
feat(uptime): add request metrics for hyper/reqwest

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -11,7 +11,7 @@ use pin_project_lite::pin_project;
 use tokio::sync::{mpsc, oneshot};
 
 #[cfg(feature = "http2")]
-use crate::{body::Incoming, proto::h2::client::ResponseFutMap};
+use crate::{body::Incoming, proto::h2::client::ResponseFutMap, RequestStats};
 
 pub(crate) type RetryPromise<T, U> = oneshot::Receiver<Result<U, TrySendError<T>>>;
 pub(crate) type Promise<T> = oneshot::Receiver<Result<T, crate::Error>>;
@@ -333,7 +333,7 @@ pin_project! {
         #[pin]
         pub(crate) when: ResponseFutMap<B>,
         #[pin]
-        pub(crate) call_back: Option<Callback<Request<B>, Response<Incoming>>>,
+        pub(crate) call_back: Option<Callback<Request<B>, (RequestStats, Response<Incoming>)>>,
     }
 }
 
@@ -350,8 +350,8 @@ where
         let mut call_back = this.call_back.take().expect("polled after complete");
 
         match Pin::new(&mut this.when).poll(cx) {
-            Poll::Ready(Ok(res)) => {
-                call_back.send(Ok(res));
+            Poll::Ready(Ok((stats, res))) => {
+                call_back.send(Ok((stats, res)));
                 Poll::Ready(())
             }
             Poll::Pending => {

--- a/src/common/io/compat.rs
+++ b/src/common/io/compat.rs
@@ -1,6 +1,8 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::rt::Stats;
+
 /// This adapts from `hyper` IO traits to the ones in Tokio.
 ///
 /// This is currently used by `h2`, and by hyper internal unit tests.
@@ -16,6 +18,22 @@ impl<T> Compat<T> {
         // SAFETY: The simplest of projections. This is just
         // a wrapper, we don't do anything that would undo the projection.
         unsafe { self.map_unchecked_mut(|me| &mut me.0) }
+    }
+}
+
+impl<T> Stats for Compat<T>
+where
+    T: Stats,
+{
+    fn stats(&mut self) -> crate::rt::ConnectionStats {
+        self.0.stats()
+    }
+}
+
+#[cfg(test)]
+impl Stats for Compat<tokio_test::io::Mock> {
+    fn stats(&mut self) -> crate::rt::ConnectionStats {
+        Default::default()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@
 //!   behavior, for the purposes of protection. It is also possible to _change_
 //!   what the default options are set to, also in efforts to protect the
 //!   most people possible.
+use std::{fmt::Display, ops::Sub};
+
 #[doc(hidden)]
 pub use http;
 
@@ -100,6 +102,189 @@ extern crate test;
 pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Uri, Version};
 
 pub use crate::error::{Error, Result};
+use crate::rt::ConnectionStats;
+
+#[derive(Clone, Copy, Debug)]
+/// Connection and request-level stats for a http request.
+pub struct RequestStats {
+    /// Connection-level stats.
+    connection_stats: ConnectionStats,
+
+    /// The apprximate instant that we started waiting for actual bytes on the connection.
+    poll_start: std::time::Instant,
+
+    /// The approximate instant the first byte of the response payload was received.
+    fbt: Option<std::time::Instant>,
+
+    /// The approximate instant we started the very last redirect this request experienced.
+    last_redirect: Option<std::time::Instant>,
+
+    /// The approximate instant we delivered the response to the caller.
+    finish: Option<std::time::Instant>,
+}
+
+impl RequestStats {
+    /// Constructs a mostly-empty RequestStats struct, with an instantaneous connection time.  
+    /// We can use that to figure out how many http2 requests we are making.
+    pub fn new_http2() -> Self {
+        let now = std::time::Instant::now();
+        Self {
+            connection_stats: ConnectionStats {
+                start_time: Some(now),
+                connect_start: Some(now),
+                connect_end: Some(now),
+                ..Default::default()
+            },
+            poll_start: now,
+            fbt: None,
+            last_redirect: None,
+            finish: None,
+        }
+    }
+    /// Returns the time the dns resolve started
+    pub fn get_dns_resolve_start(&self) -> Option<core::time::Duration> {
+        self.connection_stats.dns_resolve_start.map(|t| {
+            self.connection_stats
+                .start_time
+                .map(|start| t.duration_since(start))
+        })?
+    }
+
+    /// Returns the time the dns resolve finished
+    pub fn get_dns_resolve_end(&self) -> Option<core::time::Duration> {
+        self.connection_stats.dns_resolve_end.map(|t| {
+            self.connection_stats
+                .start_time
+                .map(|start| t.duration_since(start))
+        })?
+    }
+
+    /// Returns the time the socket connection was started
+    pub fn get_connect_start(&self) -> Option<core::time::Duration> {
+        self.connection_stats.connect_start.map(|t| {
+            self.connection_stats
+                .start_time
+                .map(|start| t.duration_since(start))
+        })?
+    }
+
+    /// Returns the time the socket finished connecting
+    pub fn get_connect_end(&self) -> Option<core::time::Duration> {
+        self.connection_stats.connect_end.map(|t| {
+            self.connection_stats
+                .start_time
+                .map(|start| t.duration_since(start))
+        })?
+    }
+
+    /// Returns the time the tls negotiation started
+    pub fn get_tls_start(&self) -> Option<core::time::Duration> {
+        self.connection_stats.tls_connect_start.map(|t| {
+            self.connection_stats
+                .start_time
+                .map(|start| t.duration_since(start))
+        })?
+    }
+
+    /// Returns the time the tls negotiation completed
+    pub fn get_tls_end(&self) -> Option<core::time::Duration> {
+        self.connection_stats.tls_connect_end.map(|t| {
+            self.connection_stats
+                .start_time
+                .map(|start| t.duration_since(start))
+        })?
+    }
+
+    /// Returns the time the socket was polled for data.  Can be zero, if the
+    /// connection was re-used from a pool
+    pub fn get_transfer_start(&self) -> core::time::Duration {
+        self.connection_stats
+            .start_time
+            .map(|start| self.poll_start.duration_since(start))
+            .unwrap_or(core::time::Duration::from_millis(0))
+    }
+
+    /// Returns the time (relative to get_transfer_start) that the first byte was received
+    /// from the server
+    pub fn get_ttfb(&self) -> Option<core::time::Duration> {
+        self.fbt.map(|t| t.duration_since(self.poll_start))
+    }
+
+    /// Returns the time (relative to get_transfer_start) that the last redirection
+    /// began (this would be the final request made in a chain of redirections)
+    pub fn get_last_redirect_start(&self) -> Option<core::time::Duration> {
+        self.last_redirect
+            .map(|t| t.duration_since(self.poll_start))
+    }
+
+    /// Returns the time the request end (this does not include body time!)
+    pub fn get_request_end(&self) -> Option<core::time::Duration> {
+        self.finish.map(|t| t.duration_since(self.poll_start))
+    }
+
+    /// Get connection stats.
+    pub fn get_connection_stats(&self) -> ConnectionStats {
+        self.connection_stats
+    }
+
+    /// Set connection stats.
+    pub fn set_connection_stats(&mut self, cs: ConnectionStats) {
+        self.connection_stats = cs;
+    }
+
+    /// Sets the instant the last redirect started.
+    pub fn set_last_redirect(&mut self, redirect: Option<std::time::Instant>) {
+        if redirect.is_some() {
+            self.last_redirect = redirect;
+        }
+    }
+
+    /// Sets the instant we started waiting for data from the server.
+    pub fn set_poll_start(&mut self, start: std::time::Instant) {
+        self.poll_start = start;
+    }
+
+    /// Sets the time this request finished.
+    pub fn set_finish(&mut self, finish: std::time::Instant) {
+        self.finish = Some(finish);
+    }
+}
+
+impl Display for RequestStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(s) = self.get_dns_resolve_start() {
+            if let Some(e) = self.get_dns_resolve_end() {
+                f.write_fmt(format_args!("name resolution: {:?}\n", e.sub(s)))?;
+            }
+        }
+
+        if let Some(s) = self.get_connect_start() {
+            if let Some(e) = self.get_connect_end() {
+                f.write_fmt(format_args!("connection: {:?}\n", e.sub(s)))?;
+            }
+        }
+
+        if let Some(s) = self.get_tls_start() {
+            if let Some(e) = self.get_tls_end() {
+                f.write_fmt(format_args!("tls negotiation: {:?}\n", e.sub(s)))?;
+            }
+        }
+
+        if let Some(e) = self.get_last_redirect_start() {
+            f.write_fmt(format_args!("redirection: {:?}\n", e))?;
+        }
+
+        if let Some(e) = self.get_ttfb() {
+            f.write_fmt(format_args!("time to first byte: {:?}\n", e))?;
+        }
+
+        if let Some(e) = self.get_request_end() {
+            f.write_fmt(format_args!("total time: {:?}\n", e))?;
+        }
+
+        Ok(())
+    }
+}
 
 #[macro_use]
 mod cfg;

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -14,7 +14,7 @@ pub use self::h2_client::Http2ClientConnExec;
 mod h2_client {
     use std::{error::Error, future::Future};
 
-    use crate::rt::{Read, Write};
+    use crate::rt::{Read, Stats, Write};
     use crate::{proto::h2::client::H2ClientFuture, rt::Executor};
 
     /// An executor to spawn http2 futures for the client.
@@ -29,7 +29,7 @@ mod h2_client {
     where
         B: http_body::Body,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
-        T: Read + Write + Unpin,
+        T: Read + Write + Stats + Unpin,
     {
         #[doc(hidden)]
         fn execute_h2_future(&mut self, future: H2ClientFuture<B, T>);
@@ -41,7 +41,7 @@ mod h2_client {
         B: http_body::Body + 'static,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
         H2ClientFuture<B, T>: Future<Output = ()>,
-        T: Read + Write + Unpin,
+        T: Read + Write + Stats + Unpin,
     {
         fn execute_h2_future(&mut self, future: H2ClientFuture<B, T>) {
             self.execute(future)
@@ -54,7 +54,7 @@ mod h2_client {
         B: http_body::Body + 'static,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
         H2ClientFuture<B, T>: Future<Output = ()>,
-        T: Read + Write + Unpin,
+        T: Read + Write + Stats + Unpin,
     {
     }
 

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self};
 use std::mem::MaybeUninit;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -40,6 +40,37 @@ pub trait Read {
         cx: &mut Context<'_>,
         buf: ReadBufCursor<'_>,
     ) -> Poll<Result<(), std::io::Error>>;
+}
+
+/// Collects connection-level statistics for a connection.
+pub trait Stats {
+    /// Get the connection statistics for this connection.
+    fn stats(&mut self) -> ConnectionStats;
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+/// Connection-level stats for http requests.
+pub struct ConnectionStats {
+    /// The approximate instant we started to process this connection.
+    pub start_time: Option<std::time::Instant>,
+
+    /// The approximate instant before we start dns resolution.
+    pub dns_resolve_start: Option<std::time::Instant>,
+
+    /// The approximate instant after we have finished dns resolution.
+    pub dns_resolve_end: Option<std::time::Instant>,
+
+    /// The approximate instant before we start establishing a TCP connection.
+    pub connect_start: Option<std::time::Instant>,
+
+    /// The approximate instant after we finish establishing a TCP connection.
+    pub connect_end: Option<std::time::Instant>,
+
+    /// The approximate instant before we start upgrading a connection to TLS.
+    pub tls_connect_start: Option<std::time::Instant>,
+
+    /// The approximate instant after we have finished upgrading a connection to TLS.
+    pub tls_connect_end: Option<std::time::Instant>,
 }
 
 /// Write bytes asynchronously.

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -11,7 +11,7 @@ pub mod bounds;
 mod io;
 mod timer;
 
-pub use self::io::{Read, ReadBuf, ReadBufCursor, Write};
+pub use self::io::{ConnectionStats, Read, ReadBuf, ReadBufCursor, Stats, Write};
 pub use self::timer::{Sleep, Timer};
 
 /// An executor of futures.

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use crate::rt::{Read, Write};
+use crate::rt::{Read, Stats, Write};
 use crate::upgrade::Upgraded;
 use bytes::Bytes;
 use futures_core::ready;
@@ -120,7 +120,7 @@ impl<I, B, S> Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin,
+    I: Read + Write + Stats + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -200,7 +200,7 @@ impl<I, B, S> Future for Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin,
+    I: Read + Write + Stats + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -438,7 +438,7 @@ impl Builder {
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         S::ResBody: 'static,
         <S::ResBody as Body>::Error: Into<Box<dyn StdError + Send + Sync>>,
-        I: Read + Write + Unpin,
+        I: Read + Write + Stats + Unpin,
     {
         let mut conn = proto::Conn::new(io);
         conn.set_h1_parser_config(self.h1_parser_config.clone());
@@ -498,7 +498,7 @@ impl<I, B, S> UpgradeableConnection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin,
+    I: Read + Write + Stats + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -519,7 +519,7 @@ impl<I, B, S> Future for UpgradeableConnection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin + Send + 'static,
+    I: Read + Write + Stats + Unpin + Send + 'static,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {


### PR DESCRIPTION
This PR introduces the ConnectionStats and RequestStats structs (and _all_ the associated promise-plumbing), as well as the request-level stats tracking.  

(hyper-util and hyper-tls depend on hyper, which are responsible for the connection-level work.  reqwest is the api-level bit, but also some of the glue that binds the connection-oriented work to the request-oriented work.)